### PR TITLE
Fix run-tests CI and enable parallel execution

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,4 +58,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --parallel

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Masterix21\\Bookings\\Tests\\": "tests"
+            "Masterix21\\Bookings\\Tests\\": "tests",
+            "Masterix21\\Bookings\\Tests\\Database\\Factories\\": "tests/database/factories"
         }
     },
     "scripts": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         verbose="true"
 >
     <testsuites>
         <testsuite name="Laravel Bookings Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+    </source>
     <php>
         <env name="CACHE_DRIVER" value="file"/>
         <env name="APP_KEY" value="base64:m+pDa0MKS1KpMlxzzdVEaqFHysv3IPhrx/3TFSWBqJA="/>

--- a/tests/Feature/Actions/BookResourceTest.php
+++ b/tests/Feature/Actions/BookResourceTest.php
@@ -28,7 +28,8 @@ beforeEach(function () {
     $this->resource = $this->createsResources(
         startsAt: now()->startOfDay(),
         endsAt: now()->addDays(7)->endOfDay(),
-        resourcesCount: 1
+        resourcesCount: 1,
+        resourcesStates: ['max' => 10]
     )->first();
 
     $this->user = User::factory()->create();


### PR DESCRIPTION
## Summary
- Migrate `phpunit.xml.dist` to the PHPUnit 12 schema. The legacy schema (removed attributes + deprecated `<coverage><include>`) triggered the run-tests failures under `pest --ci` and also broke parallel runs locally with `Filter for code coverage has not been configured`.
- Replace the deprecated `<coverage>` block with a top-level `<source>` element and drop attributes removed in PHPUnit 10+ (`convertErrorsToExceptions`, `verbose`, etc.).
- Run the test suite in parallel in CI via `pest --parallel`.

## Test Plan
- [x] `vendor/bin/pest --ci` → 202 passed (524 assertions)
- [x] `vendor/bin/pest --ci --parallel` → 202 passed across 8 processes (~30% faster)
- [x] run-tests workflow green on the PR