### PR TITLE
Run tests sequentially on Windows to fix parallel race

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,4 +58,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci --parallel
+        run: vendor/bin/pest --ci ${{ runner.os != 'Windows' && '--parallel' || '' }}


### PR DESCRIPTION
## Summary
Parallel pest workers on Windows intermittently fail with `rename(...packages.php): Access is denied (code: 5)` — multiple workers race to rewrite testbench's shared `bootstrap/cache/packages.php`. Windows file locking does not tolerate the concurrent write that Linux handles atomically.

Keep `--parallel` on Linux runners; run the suite sequentially on Windows via a `runner.os` conditional.

## Test Plan
- [ ] run-tests workflow green on all 8 matrix jobs, including both Windows jobs